### PR TITLE
Set ngrok url as callback_url interface and to be transaction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ app.use(passport.initialize());
 app.use("/v1/login", loginRouter)
 app.use("/v1/admins", adminRouter);
 app.use("/v1/users", userRouter);
-app.use("/v1/vendor", vendorRouter);
+app.use("/v1/vendors", vendorRouter);
 
 app.listen(port, () => {
   console.log(`Server listening on port ${port}.`);

--- a/src/routes/user-routes.ts
+++ b/src/routes/user-routes.ts
@@ -89,7 +89,7 @@ userRouter.post('/bill', async (req: any, res: Response) => {
 					name: full_name,
 					amount: membershipFee,
 					description: 'Bill for Premium membership',
-					callback_url: `<ngrok url that points to http://localhost:3001>/v1/vendors/membership/${userId}` // TODO: Change the url to something that BillPlz can callback on
+					callback_url: `<Set ngrok URL as interface for http://localhost:3001 (ngrok http 3001)>/v1/vendors/membership/${userId}` // TODO: Change the url to something that BillPlz can callback on
 				},{
 					headers: {
 						Authorization: `Basic ${process.env.BILLPLZ_API_SECRET_ENCODED}`

--- a/src/routes/vendor-routes.ts
+++ b/src/routes/vendor-routes.ts
@@ -1,53 +1,45 @@
 import { Membership, PrismaClient } from '@prisma/client';
 import { Response, Router } from 'express';
 
+const vendorRouter:Router = Router();
 const prisma = new PrismaClient();
 
-const vendorRouter:Router = Router();
-
 // To update user's membership after Bill was paid for
-vendorRouter.post('/membership', async (req: any, res: Response) => {
+vendorRouter.post('/membership/:userId', async (req: any, res: Response) => {
+  console.log(`updating membership status & creating payment record...`);
 
-	console.log(`updating membership status & creating payment record...`);
+  const { userId } = req.params;
+  const { id, paid_amount, state } = req.body;
 
-	const {userId} = req.params;
-	const {id, paid_amount, state} = req.body;
+	// Make a transaction instead of individual queries so as to have them succeed or fail cumulatively
+  try {
+    await prisma.$transaction(async (trx) => {
+      const updatedUser = await trx.user.update({
+        where: { id: Number(userId) },
+        data: {
+          membership: Membership.PREMIUM,
+        },
+      });
 
-	async function updateUserAndCreatePayment(){
+      const paymentMade = await trx.payment.create({
+        data: {
+          id,
+          amount: Number(paid_amount/100), // Returned in cents, hence divide by 100
+          payment_method: 'Online', // No payment method seen from the request body, hence placed Online as placeholder for now
+          status: state,
+        },
+      });
 
-		const updatedUser = await prisma.user.update({
-			where: {id: Number(userId)},
-			data:{
-				membership: Membership.PREMIUM 
-			}
-		})
-
-		const paymentMade = await prisma.payment.create({
-			data: {
-				id,
-				amount: paid_amount,
-				payment_method: 'Online', // Couldn't find from their documentation which states which payment method
-				status:state
-			}
-		})
-
-		console.log(`Updated user details after premium membership payment: ${JSON.stringify(updatedUser)}`);
-		console.log(`Premium Membership Payment made: ${JSON.stringify(paymentMade)}`)
-		res.send([updatedUser, paymentMade]);
-
-	};
-	
-	try{
-		updateUserAndCreatePayment()
-		.catch(async (e) => {
-			console.log(e);
-			res.status(500).send('Internal Server Error')
-		})
-	}
-	finally{
-		await prisma.$disconnect();
-	}
-
+      console.log(`Updated user details after premium membership payment: ${JSON.stringify(updatedUser)}`);
+      console.log(`Premium Membership Payment made: ${JSON.stringify(paymentMade)}`);
+      res.send([updatedUser, paymentMade]);
+    });
+  } catch (e) {
+    console.error(e);
+    res.status(500).send('Internal Server Error');
+  } finally {
+    await prisma.$disconnect();
+  }
 });
 
 


### PR DESCRIPTION
1. Ensure that the callback_url uses generated ngrok URL as a way to interface the http://localhost:3001 for BillPlz to interact with after payment is made by user

2. Set the callback endpoint to be a prisma transaction rather than 2 separate prisma queries as to ensure that the user's membership is updated  & payment record can be made at the same time if successful & aborted if either fails.